### PR TITLE
update doc with global rulestack admin permission dependency on FMS

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,8 +75,8 @@ There are multiple ways to specify the provider's parameters.  If overlapping va
 ### Optional
 
 - `access_key` (String) (Used for the initial `sts assume role`) AWS access key. Environment variable: `CLOUDNGFWAWS_ACCESS_KEY`. JSON conf file variable: `access-key`.
-- `arn` (String) The ARN allowing firewall, rulestack, and global rulestack admin permissions. Environment variable: `CLOUDNGFWAWS_ARN`. JSON conf file variable: `arn`.
-- `gra_arn` (String) The ARN allowing global rulestack admin permissions. This is preferentially used over the `arn` param if both are specified. Environment variable: `CLOUDNGFWAWS_GRA_ARN`. JSON conf file variable: `gra-arn`.
+- `arn` (String) The ARN allowing firewall, rulestack, and global rulestack admin permissions. Global rulestack admin permissions can be enabled only if the AWS account is onboarded by AWS Firewall Manager. Use 'lfa_arn' and 'lra_arn' if you want to enable only firewall and rulestack admin permissions. Environment variable: `CLOUDNGFWAWS_ARN`. JSON conf file variable: `arn`.
+- `gra_arn` (String) The ARN allowing global rulestack admin permissions. Global rulestack admin permissions can be enabled only if the AWS account is onboarded by AWS Firewall Manager. 'gra_arn' is preferentially used over the `arn` param if both are specified. Environment variable: `CLOUDNGFWAWS_GRA_ARN`. JSON conf file variable: `gra-arn`.
 - `headers` (Map of String) Additional HTTP headers to send with API calls. Environment variable: `CLOUDNGFWAWS_HEADERS`. JSON conf file variable: `headers`.
 - `host` (String) The hostname of the API (default: `api.us-east-1.aws.cloudngfw.paloaltonetworks.com`). Environment variable: `CLOUDNGFWAWS_HOST`. JSON conf file variable: `host`.
 - `json_config_file` (String) Retrieve provider configuration from this JSON file.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -120,7 +120,7 @@ func providerSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 			Description: addProviderParamDescription(
-				"The ARN allowing firewall, rulestack, and global rulestack admin permissions.",
+				"The ARN allowing firewall, rulestack, and global rulestack admin permissions. Global rulestack admin permissions can be enabled only if the AWS account is onboarded by AWS Firewall Manager. Use 'lfa_arn' and 'lra_arn' if you want to enable only firewall and rulestack admin permissions.",
 				"CLOUDNGFWAWS_ARN",
 				"arn",
 			),
@@ -147,7 +147,7 @@ func providerSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 			Description: addProviderParamDescription(
-				"The ARN allowing global rulestack admin permissions. This is preferentially used over the `arn` param if both are specified.",
+				"The ARN allowing global rulestack admin permissions. Global rulestack admin permissions can be enabled only if the AWS account is onboarded by AWS Firewall Manager. 'gra_arn' is preferentially used over the `arn` param if both are specified.",
 				"CLOUDNGFWAWS_GRA_ARN",
 				"gra-arn",
 			),


### PR DESCRIPTION

## Description
global rulestack admin permissions now can be enabled only for those accounts onboarded by AWS Firewall Manager.
<!--- Describe your changes in detail -->
global rulestack admin permissions now can be enabled only for those accounts onboarded by AWS Firewall Manager.
Update the doc to specify this dependency.
## Motivation and Context
global rulestack admin permissions now can be enabled only for those accounts onboarded by AWS Firewall Manager.
Update the doc with this dependency.
<!--- Why is this change required? What problem does it solve? -->
If customer specifies the 'gra_arn' or 'arn' and the account is not onboarded by AWS Firewall Manager, it will result in terraform deployment failure. Update the documentation to specify the dependency on AWS Firewall Manager.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
documentation change
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
documentation change
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
