### PR TITLE
Update Example Usage Docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Terraform 0.13 and later:
 terraform {
   required_providers {
     cloudngfwaws = {
-      source  = "paloaltonetworks/terraform-provider-cloudngfwaws"
+      source  = "paloaltonetworks/cloudngfwaws"
       version = "1.0.0"
     }
   }


### PR DESCRIPTION
## Description
Very small change to example usage section of the docs.

## Motivation and Context
Full repo name is not required for source parameter of the provider path:
```
Error: Invalid provider type
│ 
│   on cloudngfw.tf line 4, in terraform:
│    4:       source  = "paloaltonetworks/terraform-provider-cloudngfwaws"

Provider source "paloaltonetworks/terraform-provider-cloudngfwaws" has a type with the prefix "terraform-provider-", which isn't valid. Although that prefix is often used in the names
│ of version control repositories for Terraform providers, provider source strings should not include it.
│ 
│ Did you mean "paloaltonetworks/cloudngfwaws"?
```

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)
![Screenshot 2022-11-29 at 15 19 10](https://user-images.githubusercontent.com/6574404/204568757-fd21abb5-4d5b-4f7b-92b5-ef08ea3cca31.png)

## Types of changes
- Bug fix (non-breaking change which fixes an issue) - docs fix

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.