### PR TITLE
Expose firewall_id field in the ngfw resource

### DIFF
--- a/docs/data-sources/ngfw.md
+++ b/docs/data-sources/ngfw.md
@@ -42,6 +42,7 @@ data "cloudngfwaws_ngfw" "example" {
 - `description` (String) The description.
 - `endpoint_mode` (String) Set endpoint mode from the following options. Valid values are `ServiceManaged` or `CustomerManaged`.
 - `endpoint_service_name` (String) The endpoint service name.
+- `firewall_id` (String) The Id of the NGFW.
 - `global_rulestack` (String) The global rulestack for this NGFW.
 - `id` (String) The ID of this resource.
 - `link_id` (String) The link ID.

--- a/docs/resources/ngfw.md
+++ b/docs/resources/ngfw.md
@@ -101,6 +101,7 @@ resource "aws_subnet" "subnet2" {
 ### Read-Only
 
 - `endpoint_service_name` (String) The endpoint service name.
+- `firewall_id` (String) The Id of the NGFW.
 - `id` (String) The ID of this resource.
 - `link_status` (String) The link status.
 - `status` (List of Object) (see [below for nested schema](#nestedatt--status))

--- a/internal/provider/ngfw.go
+++ b/internal/provider/ngfw.go
@@ -360,6 +360,11 @@ func ngfwSchema(isResource bool, rmKeys []string) map[string]*schema.Schema {
 			Description: "The NGFW name.",
 			ForceNew:    true,
 		},
+		"firewall_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The Id of the NGFW.",
+		},
 		"vpc_id": {
 			Type:        schema.TypeString,
 			Required:    true,
@@ -559,6 +564,7 @@ func loadNgfw(d *schema.ResourceData) ngfw.Info {
 
 	return ngfw.Info{
 		Name:                         d.Get("name").(string),
+		Id:                           d.Get("firewall_id").(string),
 		VpcId:                        d.Get("vpc_id").(string),
 		AccountId:                    d.Get("account_id").(string),
 		SubnetMappings:               sm,
@@ -617,6 +623,7 @@ func saveNgfw(d *schema.ResourceData, o ngfw.ReadResponse) {
 	}
 
 	d.Set("name", o.Firewall.Name)
+	d.Set("firewall_id", o.Firewall.Id)
 	d.Set("account_id", o.Firewall.AccountId)
 	d.Set("subnet_mapping", sm)
 	d.Set("vpc_id", o.Firewall.VpcId)


### PR DESCRIPTION
The current ngfw resources don't expose the firewall_id attribute. This PR expands the resource schema to include this attribute