### PR TITLE
fix: ngfw subnet_mapping change from TypeList to TypeSet

### DIFF
--- a/internal/provider/ngfw.go
+++ b/internal/provider/ngfw.go
@@ -395,7 +395,7 @@ func ngfwSchema(isResource bool, rmKeys []string) map[string]*schema.Schema {
 			Description: "The endpoint service name.",
 		},
 		"subnet_mapping": {
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Required:    true,
 			MinItems:    1,
 			Description: "Subnet mappings.",
@@ -534,11 +534,12 @@ func ngfwSchema(isResource bool, rmKeys []string) map[string]*schema.Schema {
 
 func loadNgfw(d *schema.ResourceData) ngfw.Info {
 	var sm []ngfw.SubnetMapping
-	list := d.Get("subnet_mapping").([]interface{})
-	if len(list) > 0 {
-		sm = make([]ngfw.SubnetMapping, 0, len(list))
-		for i := range list {
-			x := list[i].(map[string]interface{})
+	smSet := d.Get("subnet_mapping").(*schema.Set)
+
+	if smSet.Len() > 0 {
+		sm = make([]ngfw.SubnetMapping, 0, smSet.Len())
+		for _, v := range smSet.List() {
+			x := v.(map[string]interface{})
 			mapping := ngfw.SubnetMapping{}
 			subnetId := x["subnet_id"].(string)
 			azName := x["availability_zone"].(string)


### PR DESCRIPTION
## Description

fixes https://github.com/PaloAltoNetworks/terraform-provider-cloudngfwaws/issues/30

## Motivation and Context

Bugfix for input `subnet_mapping`s in the `ngfw` resource. See issue: https://github.com/PaloAltoNetworks/terraform-provider-cloudngfwaws/issues/30.

## How Has This Been Tested?

Tested by planning and applying locally on my macbook. If I adjust the number of subnet mappings, e.g I have 3 subnet mappings to `eu-north-1a`, `eu-north-1b`, `eu-north-1c` and remove the one for `eu-north-1c`, it looks like all 3 are removed then re-added. However this seems to only be only how Terraform observes and updates the state; in NGFW only the relevant endpoint is removed.

Currently there are no acceptance tests for this resource. Writing tests for `ngfw` resource requires an AWS account for provisioning VPC resources.

## Screenshots (if appropriate)
n/a

## Types of changes
Bug fix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. (where?)
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.