### PR TITLE
fix: account_onboarding CFT DecryptionRole dependency

### DIFF
--- a/modules/account_onboarding/onboarding_template.yaml
+++ b/modules/account_onboarding/onboarding_template.yaml
@@ -407,7 +407,6 @@ Resources:
     - CustomNotificationLambda
     - CustomNotificationLambdaRole
     - LogMetricRole
-    - DecryptionRole
     - NetworkMonitoringRole
 
 Outputs:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixing the "DependsOn" issue for DecryptionRole in the account_onboarding CloudFormation Template.
Please see the issue description in the context for details.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #43 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with 2 AWS Accounts for automated onboarding.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
