### PR TITLE
FWAAS-18409: fix delete firewall

### DIFF
--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -124,7 +124,7 @@ func isObjectNotFound(e error) bool {
 		return e2.ObjectNotFound()
 	}
 
-	return false
+	return strings.Contains(e.Error(), "does not exist")
 }
 
 func isBadRequest(e error) bool {


### PR DESCRIPTION
isObjectNotFound now falls back to string matching on "does not exist" when the error is not a typed response.Status, ensuring delete operations correctly detect not-found errors and treat them as already-deleted.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
